### PR TITLE
Implemented optimised map directly with quoted matching

### DIFF
--- a/src/main/scala/macro.scala
+++ b/src/main/scala/macro.scala
@@ -23,33 +23,26 @@ object PipeExample {
   // }
 
   import scala.tasty._
-  case class Mapped(first: Pipe[Int], fn: Int => Int) extends Pipe[Int] {
+  case class Mapped[A, B](first: Pipe[A], fn: A => B) extends Pipe[B] {
     def toList = first.toList.map(fn)
   }
-
-  def mapImpl (first: Expr[Pipe[Int]], fn: Expr[Int => Int])(using qctx: QuoteContext): Expr[Pipe[Int]] = {
-    import qctx.tasty._
-    def go(trm : Term): Expr[Pipe[Int]] = {
-      import qctx.tasty._
-      trm match {
-        case Typed(t, _) =>
-          go(t)
-        case Inlined(_, _, t) =>
-          go(t)
-        case Apply(mapped, args@List(iFirst, iFn)) =>
-          //  qctx.tasty.warning(s"debug4 ${mapped.showExtractors} ", mapped.pos)
-          //  qctx.warning(s"debug5 ${args.map(_.showExtractors)} ${args.length}")
-          '{ Mapped(${iFirst.seal.cast[Pipe[Int]]}, ${iFn.seal.cast[Int => Int]} andThen $fn) }
-        case _ =>
-          //qctx.tasty.warning(s"debug6 ${trm.showExtractors}", trm.pos)
-          '{ Mapped($first, $fn) }
-      }
+  
+  private def mapImpl[A: Type, B: Type](first: Expr[Pipe[A]], fn: Expr[A => B])(using qctx: QuoteContext): Expr[Pipe[B]] = 
+    first match {
+      case '{ Mapped.apply[$a, A]($first, $lfn): Pipe[A] } =>
+        mapImpl(first, '{ (aa: $a) => ${ Expr.betaReduce(fn)(Expr.betaReduce(lfn)('{ aa })) } })
+      case c =>
+        qctx.warning(s"Got unsupported expression: ${c.show}", c)
+        '{ Mapped[A, B]($first, $fn) }
     }
-    go(first.unseal)
+  
+  private def logTree[A](expr: Expr[A])(using QuoteContext): Expr[A] = {
+    println(s"Optimised code: ${expr.show}")
+    expr
   }
 
   extension pipeOps {
-    inline def (inline first: => Pipe[Int]).map(inline fn: => Int => Int): Pipe[Int] =
-      ${ mapImpl('{ first }, '{ fn }) }
+    inline def [A, B](inline first: Pipe[A]).map(inline fn: A => B): Pipe[B] =
+      ${ logTree(mapImpl('{ first }, '{ fn })) }
   }
 }


### PR DESCRIPTION
Example of optimized map, using `scala.quoted`. It also optimizes lambdas, via `Expr.betaReduce`.